### PR TITLE
Mark arguments as optional in fact declaration type

### DIFF
--- a/src/dsl/types.rs
+++ b/src/dsl/types.rs
@@ -15,7 +15,7 @@ pub struct Check {
 pub struct FactDeclaration {
     pub name: String,
     pub gatherer: String,
-    pub argument: String,
+    pub argument: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
`FactDeclaration`'s `argument` field was marked as optional in the JSON schema, not in the struct. We now have both optional.