### PR TITLE
Add failure_message to Expectation type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99df8100674344d1cee346c764684f7ad688a4dcaa1a3efb2fdb45daf9acf4f9"
+checksum = "7aa5de57a62c2440ece64342ea59efb7171aa7d016faf8dfcb8795066a17146b"
 dependencies = [
  "lazy_static",
  "num",
@@ -452,9 +452,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "iso8601"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f21abb3d09069861499d93d41a970243a90e215df0cf763ac9a31b9b27178d0"
+checksum = "296af15e112ec6dc38c9fd3ae027b5337a75466e8eed757bd7d5cf742ea85eb6"
 dependencies = [
  "nom",
 ]
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f61559c2ea5fef5af856ae95443111dc14e7c9ce73d29c257a840249c0ed298"
+checksum = "fd29fa1f740be6dc91982013957e08c3c4232d7efcfe19e12da87d50bad47758"
 dependencies = [
  "ahash",
  "bitflags",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36791b0b801159db25130fd46ac726d2751c070260bba3a4a0a3eeb6231bb82a"
+checksum = "db74e3fdd29d969a0ec1f8e79171a6f0f71d0429293656901db382d248c4c021"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ clap = { version = "3.2.6", features = ["derive"] }
 colored = "2"
 jsonschema = "0.16.1"
 yaml-rust = "0.4"
-rhai = "1.11.0"
+rhai = { version = "1.13.0", features = ["internals"] }
 serde = {version = "1.0.147", features = ["derive"] }
 serde_yaml = "0.9.14"
 serde_json = "1.0.87"

--- a/src/dsl/types.rs
+++ b/src/dsl/types.rs
@@ -31,6 +31,7 @@ pub struct Expectation {
     pub name: String,
     pub expect: Option<String>,
     pub expect_same: Option<String>,
+    pub failure_message: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/dsl/validation.rs
+++ b/src/dsl/validation.rs
@@ -1,7 +1,7 @@
 use super::types::ValidationError;
 use colored::*;
 use jsonschema::{Draft, JSONSchema};
-use rhai::Engine;
+use rhai::{Engine, Expr, Stmt};
 use serde_json::json;
 
 const SCHEMA: &str = include_str!("../../wanda/guides/check_definition.schema.json");
@@ -41,29 +41,49 @@ pub fn validate(
         .as_array()
         .unwrap_or(&Vec::new())
         .iter()
-        .map(|value| {
+        .enumerate()
+        .flat_map(|(index, value)| {
             let expect = value.get("expect");
             let expect_same = value.get("expect_same");
+            let failure_message = value.get("failure_message");
 
-            let expectation_expression = if expect.is_some() {
+            let is_expect = expect.is_some();
+
+            let expectation_expression = if is_expect {
                 expect.unwrap().as_str().unwrap()
             } else {
                 expect_same.unwrap().as_str().unwrap()
             };
 
-            engine.compile(expectation_expression)
+            let mut results = vec![];
+
+            match engine.compile(expectation_expression) {
+                Ok(_) => results.push(Ok(())),
+                Err(error) => results.push(Err(ValidationError {
+                    check_id: check_id.to_string(),
+                    error: error.to_string(),
+                    instance_path: format!("/expectations/{:?}", index).to_string(),
+                })),
+            }
+
+            if failure_message.is_some() {
+                let failure_message_expression = failure_message.unwrap().as_str().unwrap();
+                results.push(validate_string_expression(
+                    failure_message_expression,
+                    engine,
+                    check_id,
+                    index,
+                    is_expect,
+                ));
+            };
+
+            results
         })
         .partition(Result::is_ok);
 
     let mut expectation_errors: Vec<ValidationError> = expectation_expression_errors
         .into_iter()
         .map(Result::unwrap_err)
-        .enumerate()
-        .map(|(index, error)| ValidationError {
-            check_id: check_id.to_string(),
-            error: error.to_string(),
-            instance_path: format!("/expectations/{:?}", index).to_string(),
-        })
         .collect();
 
     let (_, values_expression_errors): (Vec<_>, Vec<_>) = json_check
@@ -120,6 +140,59 @@ pub fn validate(
     }
 
     Err(errors)
+}
+
+fn validate_string_expression(
+    expression: &str,
+    engine: &Engine,
+    check_id: &str,
+    index: usize,
+    allow_interpolated_strings: bool,
+) -> Result<(), ValidationError> {
+    match engine.compile(format!("`{}`", expression)) {
+        Ok(ast) => {
+            let statements = ast.statements();
+            if statements.len() > 1 {
+                return Err(ValidationError {
+                    check_id: check_id.to_string(),
+                    error: "Too many statements".to_string(),
+                    instance_path: format!("/expectations/{:?}", index).to_string(),
+                });
+            }
+
+            match &statements[0] {
+                Stmt::Expr(expression) => match **expression {
+                    Expr::StringConstant(_, _) => Ok(()),
+                    Expr::InterpolatedString(_, _) => {
+                        if !allow_interpolated_strings {
+                            Err(ValidationError {
+                                check_id: check_id.to_string(),
+                                error: "String interpolation is not allowed here".to_string(),
+                                instance_path: format!("/expectations/{:?}", index).to_string(),
+                            })
+                        } else {
+                            Ok(())
+                        }
+                    }
+                    _ => Err(ValidationError {
+                        check_id: check_id.to_string(),
+                        error: "Field has to be a string".to_string(),
+                        instance_path: format!("/expectations/{:?}", index).to_string(),
+                    }),
+                },
+                _ => Err(ValidationError {
+                    check_id: check_id.to_string(),
+                    error: "Field has to be an expression".to_string(),
+                    instance_path: format!("/expectations/{:?}", index).to_string(),
+                }),
+            }
+        }
+        Err(error) => Err(ValidationError {
+            check_id: check_id.to_string(),
+            error: error.to_string(),
+            instance_path: format!("/expectations/{:?}", index).to_string(),
+        }),
+    }
 }
 
 pub fn get_json_schema() -> JSONSchema {
@@ -400,7 +473,53 @@ mod tests {
     }
 
     #[test]
-    fn validate_check_failure_message() {
+    fn validate_check_failure_message_expect_ok() {
+        let input = r#"
+            id: 156F64
+            name: Corosync configuration file
+            group: Corosync
+            description: |
+              Corosync `token` timeout is set to expected value
+            remediation: |
+              ## Abstract
+              The value of the Corosync `token` timeout is not set as recommended.
+              ## Remediation
+              ...
+            facts:
+              - name: corosync_token_timeout
+                gatherer: corosync.conf
+            values:
+              - name: expected_token_timeout
+                default: 5000
+                conditions:
+                  - value: 30000
+                    when: env.provider == "azure" || env.provider == "aws"
+                  - value: 20000
+                    when: env.provider == "gcp"
+            expectations:
+              - name: timeout
+                expect: facts.corosync_token_timeout == values.expected_token_timeout
+                failure_message: Expectation not met ${facts.corosync_token_timeout}
+        "#;
+
+        let engine = Engine::new();
+
+        let json_value: serde_json::Value =
+            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+
+        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+
+        let json_schema = get_json_schema();
+        let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
+
+        println!("{:?}", validation_result);
+
+        assert_eq!(validation_result.is_ok(), true);
+        assert_eq!(deserialization_result.is_ok(), true);
+    }
+
+    #[test]
+    fn validate_check_failure_message_expect_same_ok() {
         let input = r#"
             id: 156F64
             name: Corosync configuration file
@@ -439,7 +558,55 @@ mod tests {
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
+        println!("{:?}", validation_result);
+
         assert_eq!(validation_result.is_ok(), true);
+        assert_eq!(deserialization_result.is_ok(), true);
+    }
+
+    #[test]
+    fn validate_check_failure_message_expect_same_invalid() {
+        let input = r#"
+            id: 156F64
+            name: Corosync configuration file
+            group: Corosync
+            description: |
+              Corosync `token` timeout is set to expected value
+            remediation: |
+              ## Abstract
+              The value of the Corosync `token` timeout is not set as recommended.
+              ## Remediation
+              ...
+            facts:
+              - name: corosync_token_timeout
+                gatherer: corosync.conf
+            values:
+              - name: expected_token_timeout
+                default: 5000
+                conditions:
+                  - value: 30000
+                    when: env.provider == "azure" || env.provider == "aws"
+                  - value: 20000
+                    when: env.provider == "gcp"
+            expectations:
+              - name: timeout
+                expect_same: facts.corosync_token_timeout == values.expected_token_timeout
+                failure_message: Expectation not met ${facts.corosync_token_timeout}
+        "#;
+
+        let engine = Engine::new();
+
+        let json_value: serde_json::Value =
+            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+
+        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+
+        let json_schema = get_json_schema();
+        let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
+
+        println!("{:?}", validation_result);
+
+        assert_eq!(validation_result.is_ok(), false);
         assert_eq!(deserialization_result.is_ok(), true);
     }
 }


### PR DESCRIPTION
We can now validate string expressions using some Rhai internals.

Now Tlint checks if a failure message:

- Is a string
- Doesn't contain interpolated values in case of an `expect_same`