### PR TITLE
Update reference to check definition schema

### DIFF
--- a/check.yml
+++ b/check.yml
@@ -9,6 +9,11 @@ remediation: |
   ## Remediation
   ...
 premium: true
+metadata:
+  target_type: cluster
+  provider:
+    - aws
+    - azure
 facts:
   - name: corosync_token_timeout
     gatherer: corosync.conf

--- a/src/dsl/display.rs
+++ b/src/dsl/display.rs
@@ -11,12 +11,12 @@ fn check_header(head: &str) -> String {
     header.on_green().black().to_string()
 }
 
-pub fn print_check(check: Check) -> () {
+pub fn print_check(check: Check) {
     println!("{}  {}", check_header(&check.id), check.name);
     println!("{}  {}", check_header("Group"), check.group);
     println!("{}  {}", check_header("Description"), check.description);
     println!("\n{}", check_header("Remediation"));
-    println!("  {}", check.remediation.replace("\n", "\n  "));
+    println!("  {}", check.remediation.replace('\n', "\n  "));
     println!("\n{}", check_header("Facts"));
 
     check.facts.into_iter().for_each(|fact| {
@@ -25,6 +25,4 @@ pub fn print_check(check: Check) -> () {
     });
 
     println!("\n{}", check_header("Expectations"));
-
-    ()
 }

--- a/src/dsl/types.rs
+++ b/src/dsl/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -5,6 +7,7 @@ pub struct Check {
     pub id: String,
     pub name: String,
     pub group: String,
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
     pub when: Option<String>,
     pub description: String,
     pub remediation: String,

--- a/src/dsl/validation.rs
+++ b/src/dsl/validation.rs
@@ -271,6 +271,11 @@ mod tests {
               ## Remediation
               ...
             premium: true
+            metadata:
+              target_type: cluster
+              provider:
+                - aws
+                - azure
             facts:
               - name: corosync_token_timeout
                 gatherer: corosync.conf
@@ -295,7 +300,10 @@ mod tests {
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
+        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+
         assert_eq!(validation_result.is_ok(), true);
+        assert_eq!(deserialization_result.is_ok(), true);
     }
 
     #[test]
@@ -608,5 +616,57 @@ mod tests {
 
         assert_eq!(validation_result.is_ok(), false);
         assert_eq!(deserialization_result.is_ok(), true);
+    }
+
+    #[test]
+    fn validate_invalid_metadata() {
+        let input = r#"
+        id: 156F64
+        name: Corosync configuration file
+        group: Corosync
+        description: |
+          Corosync `token` timeout is set to expected value
+        remediation: |
+          ## Abstract
+          The value of the Corosync `token` timeout is not set as recommended.
+          ## Remediation
+          ...
+        premium: true
+        metadata:
+          "": empty
+          "  ": whitespace
+          target_type: cluster
+          provider:
+            - aws
+            - azure
+        facts:
+          - name: corosync_token_timeout
+            gatherer: corosync.conf
+            argument: totem.token
+        values:
+          - name: expected_token_timeout
+            default: 5000
+            conditions:
+              - value: 30000
+                when: env.provider == "azure" || env.provider == "aws"
+              - value: 20000
+                when: env.provider == "gcp"
+        expectations:
+          - name: timeout
+            expect: facts.corosync_token_timeout == values.expected_token_timeout
+    "#;
+
+        let engine = Engine::new();
+
+        let json_value: serde_json::Value =
+            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+        let json_schema = get_json_schema();
+        let validation_errors = validate(&json_value, "156F64", &json_schema, &engine).unwrap_err();
+        assert_eq!(validation_errors[0].check_id, "156F64");
+        assert_eq!(
+            validation_errors[0].error,
+            "Additional properties are not allowed ('', '  ' were unexpected)"
+        );
+        assert_eq!(validation_errors[0].instance_path, "/metadata");
     }
 }

--- a/src/dsl/validation.rs
+++ b/src/dsl/validation.rs
@@ -246,7 +246,7 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
         let json_schema = get_json_schema();
         let validation_errors = validate(&json_value, "156F64", &json_schema, &engine).unwrap_err();
         assert_eq!(validation_errors[0].check_id, "156F64");
@@ -296,14 +296,14 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
-        assert_eq!(validation_result.is_ok(), true);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_ok());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
         let json_schema = get_json_schema();
         let validation_errors = validate(&json_value, "156F64", &json_schema, &engine).unwrap_err();
         assert_eq!(validation_errors[0].check_id, "156F64");
@@ -383,7 +383,7 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
         let json_schema = get_json_schema();
         let validation_errors = validate(&json_value, "156F64", &json_schema, &engine).unwrap_err();
         assert_eq!(validation_errors[0].check_id, "156F64");
@@ -426,15 +426,15 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
-        assert_eq!(validation_result.is_ok(), true);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_ok());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -469,15 +469,15 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
-        assert_eq!(validation_result.is_ok(), true);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_ok());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -513,17 +513,17 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
         println!("{:?}", validation_result);
 
-        assert_eq!(validation_result.is_ok(), true);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_ok());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -559,17 +559,17 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
         println!("{:?}", validation_result);
 
-        assert_eq!(validation_result.is_ok(), true);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_ok());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -605,17 +605,17 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
 
-        let deserialization_result = serde_yaml::from_str::<Check>(&input);
+        let deserialization_result = serde_yaml::from_str::<Check>(input);
 
         let json_schema = get_json_schema();
         let validation_result = validate(&json_value, "156F64", &json_schema, &engine);
 
         println!("{:?}", validation_result);
 
-        assert_eq!(validation_result.is_ok(), false);
-        assert_eq!(deserialization_result.is_ok(), true);
+        assert!(validation_result.is_err());
+        assert!(deserialization_result.is_ok());
     }
 
     #[test]
@@ -659,7 +659,7 @@ mod tests {
         let engine = Engine::new();
 
         let json_value: serde_json::Value =
-            serde_yaml::from_str(&input).expect("Unable to parse yaml");
+            serde_yaml::from_str(input).expect("Unable to parse yaml");
         let json_schema = get_json_schema();
         let validation_errors = validate(&json_value, "156F64", &json_schema, &engine).unwrap_err();
         assert_eq!(validation_errors[0].check_id, "156F64");

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,13 +100,13 @@ fn main() -> Result<(), serde_yaml::Error> {
                                 }
                                 Ok(check) => {
                                     let check_id = check.id;
-                                    let validation_result = validation::validate(
+
+                                    validation::validate(
                                         &json_value,
                                         &check_id,
                                         &json_schema,
                                         &engine,
-                                    );
-                                    validation_result
+                                    )
                                 }
                             }
                         })
@@ -124,8 +124,7 @@ fn main() -> Result<(), serde_yaml::Error> {
 
                     validation_errors
                         .into_iter()
-                        .map(Result::unwrap_err)
-                        .flatten()
+                        .flat_map(Result::unwrap_err)
                         .for_each(
                             |ValidationError {
                                  check_id,
@@ -165,7 +164,7 @@ fn main() -> Result<(), serde_yaml::Error> {
                                  error,
                                  instance_path,
                              }| {
-                                println!("{} - {}", validation::error_header(&check_id), error);
+                                println!("{} - {}", validation::error_header(check_id), error);
                                 println!("  path: {}\n", instance_path);
                             },
                         );


### PR DESCRIPTION
Uses latest checks definition schema.

Allows wanda and premium checks pipelines to pass with the latest changes to metadata.