### PR TITLE
Add expect enum validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tlint"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "assert_cmd",
  "clap 3.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlint"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Validation engine for Trento Checks DSL.
 ## Usage
 ```sh
 $ tlint -h
-tlint 0.9.2
+tlint 0.9.3
 
 USAGE:
     tlint <SUBCOMMAND>

--- a/src/dsl/types.rs
+++ b/src/dsl/types.rs
@@ -34,7 +34,9 @@ pub struct Expectation {
     pub name: String,
     pub expect: Option<String>,
     pub expect_same: Option<String>,
+    pub expect_enum: Option<String>,
     pub failure_message: Option<String>,
+    pub warning_message: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/dsl/validation.rs
+++ b/src/dsl/validation.rs
@@ -53,8 +53,6 @@ pub fn validate(
             let is_expect_same = expect_same.is_some();
             let is_expect_enum = expect_enum.is_some();
 
-            let mut results = vec![];
-
             let expectation_expression = if is_expect {
               expect.unwrap().as_str().unwrap()
             } else if is_expect_same {
@@ -65,6 +63,8 @@ pub fn validate(
               ""
             };
 
+            let mut results = vec![];
+
             match engine.compile(expectation_expression) {
                 Ok(_) => results.push(Ok(())),
                 Err(error) => results.push(Err(ValidationError {
@@ -72,7 +72,7 @@ pub fn validate(
                     error: error.to_string(),
                     instance_path: format!("/expectations/{:?}", index).to_string(),
                 })),
-            };
+            }
 
             if failure_message.is_some() {
                 let failure_message_expression = failure_message.unwrap().as_str().unwrap();
@@ -83,14 +83,14 @@ pub fn validate(
                     index,
                     is_expect,
                 ));
-            };
+            }
 
             if warning_message.is_some() && !is_expect_enum {
               results.push(Err(ValidationError {
                 check_id: check_id.to_string(),
                 error: "warning_message is only available for expect_enum expectations".to_string(),
                 instance_path: format!("/expectations/{:?}", index).to_string(),
-              }))
+              }));
             } else if warning_message.is_some() {
               let warning_message_expression = warning_message.unwrap().as_str().unwrap();
               results.push(validate_string_expression(
@@ -100,7 +100,7 @@ pub fn validate(
                   index,
                   is_expect_enum,
               ));
-            };
+            }
 
             if is_expect_enum {
               results.append(&mut validate_expect_enum_content(
@@ -108,7 +108,7 @@ pub fn validate(
                 check_id,
                 index,
               ));
-            };
+            }
 
             results
         })


### PR DESCRIPTION
Add `expect_enum` expectation type validation.
Having one of `expect/expect_same/expect_enum` entry in the expectation is tested by json schema: https://github.com/trento-project/wanda/pull/374

PD: I have updated the lock file manually. Running the `cargo generate-lockfile` is including a loooot of changes, so maybe it will be better to do it in a different PR. I hope it is alright.