### PR TITLE
Fix failure_message validation in expect_enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tlint"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "assert_cmd",
  "clap 3.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlint"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Validation engine for Trento Checks DSL.
 ## Usage
 ```sh
 $ tlint -h
-tlint 0.9.3
+tlint 0.9.4
 
 USAGE:
     tlint <SUBCOMMAND>


### PR DESCRIPTION
Fix failure_message validation in expect_enum.
The validation was complaining in the `failure_message` validation as I didn't include the `expect_enum` boolean in the first `allow_string_interpolation` argument properly.
I should've include this test in the first implementation :sweat_smile: 