### PR TITLE
Update Wanda's Checks schema test

### DIFF
--- a/tests/fixtures/check.yml
+++ b/tests/fixtures/check.yml
@@ -26,6 +26,17 @@ values:
         when: env.provider == "azure" || env.provider == "aws"
       - value: 20000
         when: env.provider == "gcp"
+  - name: resource_order
+    default:
+      - IPaddr2
+      - SAPStartSrv
+      - SAPInstance
+    conditions:
+      - when: env.provider == "aws"
+        value:
+          - IPaddr2
+          - SAPStartSrv
+          - SAPInstance
 expectations:
   - name: timeout
     expect: facts.corosync_token_timeout == values.expected_token_timeout


### PR DESCRIPTION
Note: https://github.com/trento-project/wanda/pull/435 needs to be merged before this PR.

This PR updates the test fixture to test the new schema in https://github.com/trento-project/wanda/pull/435.