### PR TITLE
Bump rust to 1.82 in the builder dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65 as builder
+FROM rust:1.82 as builder
 
 WORKDIR /home/tlint/
 


### PR DESCRIPTION
The build on main is failing due to this, I just updated the version.