### PR TITLE
[TRNT-4327] Update dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,79 @@
-FROM rust:1.88 as builder
+ARG RUST_VERSION=1.88
+ARG OS_VER=15.7
+
+# Base build image
+FROM registry.suse.com/bci/rust:${RUST_VERSION} AS builder
 
 WORKDIR /home/tlint/
 
-COPY . .
-RUN cargo build --release
+RUN set -euo pipefail; \
+    zypper -n install --no-recommends libopenssl-devel
 
-FROM registry.suse.com/bci/rust:latest
+# Build dependencies first and cache them
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src && \
+    printf 'fn main() {}\n' > src/main.rs && \
+    printf '' > src/lib.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/home/tlint/target \
+    cargo build --release
 
-WORKDIR /home/tlint/
-COPY --from=builder /home/tlint/target/release/tlint .
-RUN zypper in -y tar gzip xz
+# Copy the actual source code and build the final binary
+COPY src ./src
+COPY wanda/guides/check_definition.schema.json ./wanda/guides/check_definition.schema.json
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/home/tlint/target \
+    touch src/lib.rs src/main.rs && \
+    cargo build --release && \
+    cp target/release/tlint /home/tlint/tlint
+
+FROM registry.suse.com/bci/bci-base:${OS_VER}
+
+ARG OS_VER
+
+# Copy the built binary from the builder stage
+COPY --from=builder /home/tlint/tlint /home/tlint/tlint
+
+# Install runtime dependencies
+RUN set -euo pipefail; \
+    zypper -n install --no-recommends tar gzip xz
+
+# Cleanup logs and temporary files
+RUN set -euo pipefail; zypper -n clean -a; \
+    rm -rf {/target,}/var/log/{alternatives.log,lastlog,tallylog,zypper.log,zypp/history,YaST2}; \
+    rm -rf {/target,}/run/*; \
+    rm -f {/target,}/etc/{shadow-,group-,passwd-,.pwd.lock}; \
+    rm -f {/target,}/usr/lib/sysimage/rpm/.rpm.lock; \
+    rm -f {/target,}/var/lib/zypp/AnonymousUniqueId; \
+    rm -f {/target,}/var/lib/zypp/AutoInstalled; \
+    rm -f {/target,}/var/cache/ldconfig/aux-cache
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.trento
+LABEL org.opencontainers.image.authors="https://github.com/trento-project/tlint/graphs/contributors"
+LABEL org.opencontainers.image.title="Trento Checks Ecosystem Linting Tool"
+LABEL org.opencontainers.image.description="Trento Checks Ecosystem Linting Tool"
+LABEL org.opencontainers.image.documentation="https://www.trento-project.io/docs/tlint/README.html"
+LABEL org.opencontainers.image.version="devel"
+LABEL org.opencontainers.image.url="https://github.com/trento-project/tlint"
+# LABEL org.opencontainers.image.created="" # Set by GHA, no need to set here
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="https://github.com/trento-project/tlint"
+LABEL org.opencontainers.image.ref.name="${OS_VER}-devel"
+LABEL org.opensuse.reference="registry.suse.com/bci/bci-micro:${OS_VER}"
+LABEL org.openbuildservice.disturl="https://github.com/trento-project/tlint/pkgs/container/tlint"
+# endlabelprefix
+LABEL org.opencontainers.image.base.name="registry.suse.com/bci/bci-micro:${OS_VER}"
+LABEL org.opencontainers.image.base.digest="latest"
+LABEL io.artifacthub.package.logo-url="https://www.trento-project.io/images/trento-icon.svg"
+LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/trento-project/tlint/refs/heads/main/README.adoc"
+
+
 WORKDIR /data
+
 VOLUME ["/data"]
+
+USER 1001
+
 ENTRYPOINT ["/home/tlint/tlint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN set -euo pipefail; zypper -n clean -a; \
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.authors="https://github.com/trento-project/tlint/graphs/contributors"
-LABEL org.opencontainers.image.title="Trento Checks Ecosystem Linting Tool"
-LABEL org.opencontainers.image.description="Trento Checks Ecosystem Linting Tool"
+LABEL org.opencontainers.image.title="TLint"
+LABEL org.opencontainers.image.description="Validation engine for Trento Checks DSL"
 LABEL org.opencontainers.image.documentation="https://www.trento-project.io/docs/tlint/README.html"
 LABEL org.opencontainers.image.version="devel"
 LABEL org.opencontainers.image.url="https://github.com/trento-project/tlint"
@@ -61,10 +61,10 @@ LABEL org.opencontainers.image.url="https://github.com/trento-project/tlint"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="https://github.com/trento-project/tlint"
 LABEL org.opencontainers.image.ref.name="${OS_VER}-devel"
-LABEL org.opensuse.reference="registry.suse.com/bci/bci-micro:${OS_VER}"
+LABEL org.opensuse.reference="registry.suse.com/bci/bci-base:${OS_VER}"
 LABEL org.openbuildservice.disturl="https://github.com/trento-project/tlint/pkgs/container/tlint"
 # endlabelprefix
-LABEL org.opencontainers.image.base.name="registry.suse.com/bci/bci-micro:${OS_VER}"
+LABEL org.opencontainers.image.base.name="registry.suse.com/bci/bci-base:${OS_VER}"
 LABEL org.opencontainers.image.base.digest="latest"
 LABEL io.artifacthub.package.logo-url="https://www.trento-project.io/images/trento-icon.svg"
 LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/trento-project/tlint/refs/heads/main/README.adoc"


### PR DESCRIPTION
Currently, this image is too big (+500MB)

This is because we are using the Rust toolchain container as the base image. We just need a slim image to run the binary.

This PR updates the Dockerfile to follow a similar pattern to other Trento projects.

See the differences:

```console
ghcr.io/trento-project/tlint:latest         8a3e9c406eb       2.18GB          556MB  
tlint:latest                                cccdba379698       235MB         63.2MB        
```